### PR TITLE
Fix(backend): Update golangci-lint to v1.59.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: '1.24.x'
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
       - name: Run golangci-lint
         working-directory: ./backend
         run: |


### PR DESCRIPTION
Updates the version of golangci-lint used in the GitHub Actions workflow to v1.59.1. This is an attempt to resolve the "internal error in importing \"internal/goarch\" (unsupported version: 2)" error encountered with Go 1.24.3.