### PR TITLE
Fix(backend): Disable goanalysis_metalinter in golangci-lint

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  disable:
+    - goanalysis_metalinter


### PR DESCRIPTION
Adds a .golangci.yml configuration file to the backend directory to disable the goanalysis_metalinter.

This linter was causing errors related to Go version incompatibility ("internal error in importing \"internal/goarch\" (unsupported version: 2)") with Go 1.24.3 that were not resolved by updating golangci-lint to v1.59.1. Disabling this specific linter is a workaround to allow the rest of the linting process to complete successfully.