### PR TITLE
Fix(ci): Use Go 1.23 for lint-backend job, Go 1.24 for others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.23.x'
       - name: Install golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24.x'
       - name: Run Go tests
         working-directory: ./backend
         run: go test -v ./...
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24.x'
       - name: Build Go application
         working-directory: ./backend
         run: go build -v -o app .

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,3 +1,0 @@
-linters:
-  disable:
-    - typecheck


### PR DESCRIPTION
Adjusts the Go version in the GitHub Actions workflow:
- The `lint-backend` job now uses Go 1.23.x. This is an attempt to resolve persistent `golangci-lint` errors related to "internal error in importing \"internal/goarch\" (unsupported version: 2)" that occurred when linting with Go 1.24.x.
- The `test-backend` and `build-backend` jobs are updated to explicitly use Go 1.24.x.
- The `backend/.golangci.yml` file (which attempted to disable linters) has been removed as it was not effective in resolving the issue.