### PR TITLE
Fix(ci): Enforce Go 1.23 for golangci-lint execution and targeting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,23 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23.x'
+      - name: Verify Go version
+        run: |
+          echo "Go version:"
+          go version
+          echo "GOROOT:"
+          go env GOROOT
+          echo "GOTOOLDIR:"
+          go env GOTOOLDIR
+          echo "which go:"
+          which go
       - name: Install golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
       - name: Run golangci-lint
         working-directory: ./backend
         run: |
-          $(go env GOPATH)/bin/golangci-lint run ./... --timeout 5m
+          $(go env GOPATH)/bin/golangci-lint run ./... --timeout 5m --go=1.23
 
   test-backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit refines the GitHub Actions workflow for the `lint-backend` job to more strictly enforce the use of Go 1.23.x:

- Ensures `actions/setup-go` specifies `go-version: '1.23.x'`.
- Adds a verification step to output `go version`, `go env GOROOT`, `go env GOTOOLDIR`, and `which go` to confirm the active Go environment before `golangci-lint` runs.
- Modifies the `golangci-lint` command to include the `--go=1.23` flag. This explicitly tells `golangci-lint` to apply Go 1.23 rules and interpret the code as Go 1.23, which should prevent it from attempting to use or download parts of the Go 1.24 toolchain that were causing "internal/goarch" errors.