### PR TITLE
Fix(ci): Use Docker image for golangci-lint in lint-backend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,26 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.23.x'
-      - name: Verify Go version
+      - name: Lint Go code
         run: |
-          echo "Go version:"
-          go version
-          echo "GOROOT:"
-          go env GOROOT
-          echo "GOTOOLDIR:"
-          go env GOTOOLDIR
-          echo "which go:"
-          which go
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
-      - name: Run golangci-lint
-        working-directory: ./backend
-        run: |
-          $(go env GOPATH)/bin/golangci-lint run ./... --timeout 5m --go=1.23
+          docker run --rm -v $(pwd)/backend:/app -w /app golangci/golangci-lint:v1.59.1-alpine golangci-lint run ./... --timeout 5m --go=1.23
 
   test-backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switches the `lint-backend` job in the GitHub Actions workflow to use the official `golangci/golangci-lint:v1.59.1-alpine` Docker image.

This change aims to provide a fully isolated and controlled environment for `golangci-lint`. By running it within a container, we can prevent unexpected Go toolchain discovery issues that were causing `golangci-lint` to attempt to download and use Go 1.24 components (despite configurations to use Go 1.23), which led to "internal/goarch" errors.

The Docker command mounts the backend code into the container and still utilizes the `--go=1.23` flag to guide `golangci-lint` on the target Go version for linting rules.

This replaces the previous approach of manually setting up Go and installing `golangci-lint` for this specific job.