### PR TITLE
Fix(backend): Temporarily downgrade to Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.59.1
       - name: Lint Go code
-        run: |
-          docker run --rm -v $(pwd)/backend:/app -w /app golangci/golangci-lint:v1.59.1-alpine golangci-lint run ./... --timeout 5m --go=1.23
+        working-directory: ./backend
+        run: $(go env GOPATH)/bin/golangci-lint run ./... --timeout 5m
 
   test-backend:
     runs-on: ubuntu-latest
@@ -22,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.23.x'
       - name: Run Go tests
         working-directory: ./backend
         run: go test -v ./...
@@ -33,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.23.x'
       - name: Build Go application
         working-directory: ./backend
         run: go build -v -o app .

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module github.com/example/project/backend
 
-go 1.24.3
+go 1.23


### PR DESCRIPTION
This commit temporarily downgrades the backend module and its CI pipeline jobs to use Go 1.23.

- The `go` directive in `backend/go.mod` is changed from `1.24` to `1.23`.
- All backend jobs (`lint-backend`, `test-backend`, `build-backend`) in the GitHub Actions workflow (`.github/workflows/ci.yml`) are updated to use Go version `1.23.x`.
- The `lint-backend` job is reverted to a simpler setup using `actions/setup-go` and script-based `golangci-lint` installation, as the Docker approach is not necessary with Go 1.23.

This change is a workaround for persistent compatibility issues encountered with `golangci-lint` (v1.59.1) when the project was configured for Go 1.24, specifically errors related to "internal error in importing \"internal/goarch\" (unsupported version: 2)".

The project can be upgraded back to Go 1.24 once `golangci-lint` provides a version that fully supports Go 1.24.3 without this issue.