### PR TITLE
feat(backend): Generate initial DB schema, migrations, and sqlc setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+DB_URL ?= "postgresql://user:password@localhost:5432/database_name?sslmode=disable"
+
+migrate-up:
+	migrate -database "$(DB_URL)" -path backend/migrations up
+
+migrate-down:
+	migrate -database "$(DB_URL)" -path backend/migrations down
+
+.PHONY: migrate-up migrate-down

--- a/backend/migrations/000001_initial_schema.down.sql
+++ b/backend/migrations/000001_initial_schema.down.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS listening_sessions;
+DROP TABLE IF EXISTS chat_messages;
+DROP TABLE IF EXISTS user_preferences;
+DROP TABLE IF EXISTS playlist_tracks;
+DROP TABLE IF EXISTS playlists;
+DROP TABLE IF EXISTS tracks;
+DROP TABLE IF EXISTS albums;
+DROP TABLE IF EXISTS artists;
+DROP TABLE IF EXISTS users;

--- a/backend/migrations/000001_initial_schema.up.sql
+++ b/backend/migrations/000001_initial_schema.up.sql
@@ -1,0 +1,92 @@
+-- Users Table
+CREATE TABLE users (
+    id UUID PRIMARY KEY,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    title VARCHAR(100),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Artists Table
+CREATE TABLE artists (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    bio TEXT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Albums Table
+CREATE TABLE albums (
+    id UUID PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    artist_id UUID REFERENCES artists(id) ON DELETE CASCADE,
+    release_date DATE,
+    genre VARCHAR(100),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tracks Table
+CREATE TABLE tracks (
+    id UUID PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    album_id UUID REFERENCES albums(id) ON DELETE CASCADE,
+    artist_id UUID REFERENCES artists(id) ON DELETE SET NULL,
+    duration INTEGER,
+    file_path VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Playlists Table
+CREATE TABLE playlists (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Playlist Tracks Table
+CREATE TABLE playlist_tracks (
+    playlist_id UUID REFERENCES playlists(id) ON DELETE CASCADE,
+    track_id UUID REFERENCES tracks(id) ON DELETE CASCADE,
+    added_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (playlist_id, track_id)
+);
+
+-- User Preferences Table
+CREATE TABLE user_preferences (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    theme VARCHAR(50),
+    language VARCHAR(10),
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Chat Messages Table
+CREATE TABLE chat_messages (
+    id UUID PRIMARY KEY,
+    sender_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    receiver_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    message TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Listening Sessions Table
+CREATE TABLE listening_sessions (
+    id UUID PRIMARY KEY,
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+    track_id UUID REFERENCES tracks(id) ON DELETE SET NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Seed Super User
+INSERT INTO users (id, username, email, password_hash, title)
+VALUES ('a1b2c3d4-e5f6-7890-1234-567890abcdef', 'fabiomigueldp', 'fabiomigueldp@example.com', '$2b$12$7WufjZE.6qtRC5UrKCpHQe5/sSFsZC2DNcfHbRxzv0qbvMA1dyhc2', 'torbsführer');

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -1,0 +1,15 @@
+version: "2"
+sql:
+  - engine: "postgresql"
+    schema: "./migrations"
+    queries: "./sql/queries" # Assuming queries will be placed here, can be an empty dir for now
+    gen:
+      go:
+        package: "db"
+        out: "./db"
+        sql_package: "pgx/v5"
+        emit_json_tags: true
+        emit_prepared_queries: false
+        emit_interface: true
+        emit_exact_table_names: false
+        emit_empty_slices: true

--- a/generate_hash.py
+++ b/generate_hash.py
@@ -1,0 +1,7 @@
+import bcrypt
+
+password = b"abc1d2aa"
+# Generate salt with a cost factor of 12
+salt = bcrypt.gensalt(rounds=12)
+hashed_password = bcrypt.hashpw(password, salt)
+print(hashed_password.decode('utf-8'))


### PR DESCRIPTION
Generates the following:
- PostgreSQL migration files (up and down) for the initial database schema.
  - Includes tables: users, artists, albums, tracks, playlists, playlist_tracks, user_preferences, chat_messages, listening_sessions.
  - Seeds a super-user 'fabiomigueldp' with username, title, and a pre-generated bcrypt hash for the password "abc1d2aa".
- sqlc.yaml configuration file in the backend directory for type-safe query generation.
- Makefile with migrate-up and migrate-down targets using golang-migrate/migrate.

This fulfills the requirements for TRB-2 to set up the initial database structure and tooling.